### PR TITLE
Fixing Fail on checking "in None"

### DIFF
--- a/extensions/latex_mods.py
+++ b/extensions/latex_mods.py
@@ -65,14 +65,15 @@ class DocTranslator(BaseTranslator):
 
     def depart_table(self, node):
         self.body = self._body
+        colspec = self.table.colspec or ''
 
-        if 'p{' in self.table.colspec or 'm{' in self.table.colspec or 'b{' in self.table.colspec:
+        if 'p{' in colspec or 'm{' in colspec or 'b{' in colspec:
             self.body.append('\n\\bodyspacing\n')
 
         self.body.append('\n\\begin{tabular}')
 
-        if self.table.colspec:
-            self.body.append(self.table.colspec)
+        if colspec:
+            self.body.append(colspec)
         else:
             self.body.append('{|' + ('l|' * self.table.colcount) + '}')
 


### PR DESCRIPTION
tables without colspec might lead to a little unhappy error. `latex_mod.py`'s `depart_table()` checks if some strings are in the `colspec`, but if `colspec` is None, the whole program will fail. Therefore I think it might be a good idea to replace the instances in which `colspec` is empty/None/False with an empty string. Checking for something `in` empty strings is okay.

The rest of the changes just remove some whitespace.
