### PR TITLE
ext/latex_mods: Fix TypeError for alt tags

### DIFF
--- a/extensions/latex_mods.py
+++ b/extensions/latex_mods.py
@@ -27,7 +27,7 @@ class DocTranslator(BaseTranslator):
         else:
             look_node = node.parent
 
-        short_caption = look_node.get('alt', '').translate(tex_escape_map)
+        short_caption = unicode(look_node.get('alt', '')).translate(tex_escape_map)
         if short_caption != "":
             short_caption = '[%s]' % short_caption
 


### PR DESCRIPTION
When not using alt tags on figures, latex_mods.py failed with a TypeError. The
problem was, that the strings are not necessarily unicode, but the escape_map
used only works with unicodes.

Fixes #12

Signed-off-by: Erik Bernoth erik.bernoth@gmail.com
