### PR TITLE
Update to preamble._tex -- 'inconsolata.sty' changed to 'zi4.sty'

### DIFF
--- a/tex/preamble._tex
+++ b/tex/preamble._tex
@@ -71,7 +71,7 @@
 
 % for code listings
 \usepackage{listings}
-\usepackage{zi4} % change default shitty typewriter font
+\IfFileExists{inconsolata.sty}{\usepackage{inconsolata}}{\usepackage{zi4}}
 \usepackage{color}
 \definecolor{codebg}{RGB}{248,248,248} % mimics html code style
 \definecolor{codeborder}{RGB}{204,204,204}


### PR DESCRIPTION
Around June this year there were major changes made to the inconsolata style file. Subsequently, within LaTeX the _style_ file was renamed from 'inconsolata.sty' to 'zi4.sty'. Somewhat confusingly, the _package_ name renames the same (inconsolata):

http://www.ctan.org/tex-archive/fonts/inconsolata/tex

Within MikTeX 2.9, in the current version of the inconsolata package (version 1.03, released 2013-07-29), the same change is reflected. More information here:
http://tex.stackexchange.com/questions/119925/inconsolata-missing-after-miktex-update

This update to the `pramble._tex` reflects this change to maintain compatibility with current version of MikTex (and I suspect other LaTeX distributons).
