### PR TITLE
decode epilog

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -76,7 +76,7 @@ else:
 
 # A string of reStructuredText that will be included at the end of
 # every source file that is read.
-rst_epilog = open(os.path.join(CURDIR, 'epilog.rst'), 'r').read()
+rst_epilog = open(os.path.join(CURDIR, 'epilog.rst'),'r').read().decode('utf8')
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
The epilog.rst file is included in the conf.py. But the data is only read()
without a decode(). This can lead to parse errors. Therefore decoding it to
utf8 is the right way to go.
