### PR TITLE
Update Jeff Terrace's PhD Thesis link

### DIFF
--- a/ch-intro/index.rst
+++ b/ch-intro/index.rst
@@ -93,4 +93,4 @@ The following changes and additions have been made from vanilla Sphinx:
 Documents Using sphinxtr
 ========================
 
-* `Jeff Terrace's PhD Thesis <http://www.cs.princeton.edu/~jterrace/thesis/>`_
+* `Jeff Terrace's PhD Thesis <http://jeffterrace.com/thesis/>`_


### PR DESCRIPTION
The old one is a redirect to http://jeffterrace.com/ where no PhD thesis is to be found.